### PR TITLE
Naprawić literówkę w dokumentacji dla GET /auth/is-unique-login

### DIFF
--- a/Api/Controllers/AuthController.cs
+++ b/Api/Controllers/AuthController.cs
@@ -138,7 +138,7 @@ public class AuthController(
     }
 
     /// <summary>
-    /// check if login is aviable
+    /// Check if login is available
     /// </summary>
     [HttpGet("is-unique-login")]
     [ProducesResponseType(200)]


### PR DESCRIPTION
Ten pull request ma na celu:
- Naprawienie literówki w dokumentacji dla końcówki `GET /auth/is-unique-login`: "aviable" -> "available";
- Napisanie pierwszego słowa dokumentacji wspomnianej wyżej końcówki dużą literą

### Dlaczego uważam, iż zmiana taka jest potrzebna
My dążymy do przytrzymywania się reguł ortografii, gramatyki oraz interpunkcji dla zapewnienia maksymalnej czytelności, a także zrozumiałości zarówno kodu, jak i dokumentacji.

Niestety, jak zostało zauważono w #88, mimo to, iż każdy pull request jest rzetelnie sprawdzany, doszło do dodania linii kodu z literówką do głównego brancha. Proszę więc o zmergowanie danego pull requesta, dla naprawienia tego przykrego błędu.